### PR TITLE
Suggested changes 

### DIFF
--- a/src/sudo/pam.rs
+++ b/src/sudo/pam.rs
@@ -150,12 +150,15 @@ pub fn attempt_authenticate<C: Converser>(
             }
 
             // there was an authentication error, we can retry
-            Err(PamError::Pam(PamErrorType::AuthError | PamErrorType::ConversationError, _)) => {
+            Err(PamError::Pam(
+                err_type @ (PamErrorType::AuthError | PamErrorType::ConversationError),
+                _,
+            )) => {
                 max_tries -= 1;
-                if max_tries == 0 {
-                    return Err(Error::MaxAuthAttempts(current_try));
-                } else if non_interactive {
+                if non_interactive || err_type == PamErrorType::ConversationError {
                     return Err(Error::InteractionRequired);
+                } else if max_tries == 0 {
+                    return Err(Error::MaxAuthAttempts(current_try));
                 } else {
                     user_warn!("Authentication failed, try again.");
                 }


### PR DESCRIPTION
Related to https://github.com/trifectatechfoundation/sudo-rs/pull/925

- If we are in non-interactive mode (`sudo -n`), why not always give 'interaction is required' as error even if max tries is 0 for some odd reason?
- If a conversation failed, why not also give that same error (it feels appropriate).

I don't necessarily like the funky `@` syntax but at the same time, I can't think of a more compact way to write it at this time.