### PR TITLE
Suggestions for NOEXEC PR

### DIFF
--- a/src/exec/noexec.rs
+++ b/src/exec/noexec.rs
@@ -180,7 +180,7 @@ pub(crate) fn add_noexec_filter(command: &mut Command, file_closer: &mut FileClo
         let mut control: SingleRightAnciliaryData = unsafe { zeroed() };
         // SAFETY: The buf field is valid when zero-initialized.
         msg.msg_controllen = unsafe { control.buf.len() };
-        msg.msg_control = &mut control as *mut _ as *mut _;
+        msg.msg_control = &mut control as *mut _ as *mut libc::c_void;
 
         // SAFETY: A valid socket fd and a valid initialized msghdr are passed in.
         if unsafe { recvmsg(rx_fd.as_raw_fd(), &mut msg, 0) } == -1 {


### PR DESCRIPTION
Review of https://github.com/trifectatechfoundation/sudo-rs/pull/1073

Instead of using github's suggestions I rolled these into separate commits and I suggest looking at them commit-by-commit.

1. creates a `ioctl` wrapper that avoid duplicating logic
2. moves the first `loop { ...; break }` into the second loop, by replacing the `break` with updating the `flags` and `error` (see point 6)
3. is self-explanatory
4. only updates comments and messages that should never be seen by users
5. moves the send/receive logic into separate functions. I think having the type signatures here helps make sense of the code since it separates the programming of the seccomp filter from the rolled-our-own socket handling code.
6. ~~for symmetry between `send_fd` and `receive_fd`~~ removed
6. re-introduces the two loops but using a closure to avoid WET