### PR TITLE
Refactor pam rpassword simplifications

### DIFF
--- a/src/pam/rpassword.rs
+++ b/src/pam/rpassword.rs
@@ -275,11 +275,10 @@ impl Terminal<'_> {
         timeout: Option<Duration>,
         hidden: Hidden<()>,
     ) -> io::Result<PamBuffer> {
-        //note for the reviewer: these explicit lifetimes are not necessary
-        fn do_hide_input<'a>(
+        fn do_hide_input(
             hidden: Hidden<()>,
-            input: BorrowedFd<'a>,
-        ) -> Result<Hidden<HiddenInput<'a>>, io::Error> {
+            input: BorrowedFd,
+        ) -> Result<Hidden<HiddenInput>, io::Error> {
             Ok(match hidden {
                 // If input is not a tty, we can't hide feedback.
                 _ if !safe_isatty(input) => Hidden::No,

--- a/src/pam/rpassword.rs
+++ b/src/pam/rpassword.rs
@@ -88,21 +88,11 @@ pub(super) enum Hidden<T> {
     WithFeedback(T),
 }
 
-impl<T> Hidden<T> {
-    fn as_ref(&self) -> Hidden<&T> {
-        match self {
-            Hidden::No => Hidden::No,
-            Hidden::Yes(x) => Hidden::Yes(x),
-            Hidden::WithFeedback(x) => Hidden::WithFeedback(x),
-        }
-    }
-}
-
 /// Reads a password from the given file descriptor while optionally showing feedback to the user.
 fn read_unbuffered(
     source: &mut dyn io::Read,
     sink: &mut dyn io::Write,
-    hide_input: Hidden<&HiddenInput>,
+    hide_input: &Hidden<HiddenInput>,
 ) -> io::Result<PamBuffer> {
     struct ExitGuard<'a> {
         pw_len: usize,
@@ -306,14 +296,14 @@ impl Terminal<'_> {
 
                 let hide_input = do_hide_input(hidden, stdin.as_fd())?;
                 let mut reader = TimeoutRead::new(stdin.as_fd(), timeout);
-                read_unbuffered(&mut reader, stdout, hide_input.as_ref())
+                read_unbuffered(&mut reader, stdout, &hide_input)
             }
             Terminal::Tty(file) => {
                 write_unbuffered(file, prompt.as_bytes())?;
 
                 let hide_input = do_hide_input(hidden, file.as_fd())?;
                 let mut reader = TimeoutRead::new(file.as_fd(), timeout);
-                read_unbuffered(&mut reader, &mut &*file, hide_input.as_ref())
+                read_unbuffered(&mut reader, &mut &*file, &hide_input)
             }
         }
     }


### PR DESCRIPTION
I'm always a bit suspicious when cloning is introduced in a place where I don't expect it or functional-structural patterns are introduced (like `.as_ref()`) for very simple type; in this case I managed to get rid of the clutter.

It's an interesting question to me why in the `fn do_hide_input` case Rust can solve the lifetime puzzle but not in the Closure case, but let's discuss that in person.

This PR can be squashed